### PR TITLE
Automatically detect if an item is a tool

### DIFF
--- a/BuildCameraCHE.cs
+++ b/BuildCameraCHE.cs
@@ -31,8 +31,6 @@ namespace Valheim_Build_Camera
 		private const string VERSION = "1.6.2";
 		private const string PluginName = "Build Camera";
 
-		private const string DEFAULT_TOOL_NAMES = "item_hammer,item_cultivator,item_hoe,PlumgaPlantItShovel,PlumgaClutterTool,ImprovedHammer,odin_hammer";
-
 		private static ConfigFile configFile = new ConfigFile(Path.Combine(Paths.ConfigPath, "Build Camera.cfg"), true);
 
 		private static ConfigEntry<float> distanceCanBuildFromAvatar
@@ -63,10 +61,6 @@ namespace Valheim_Build_Camera
 			= configFile.Bind("General", "Verbose_Logging", false,
 				"When true, increases verbosity of logging. Enable this if you're wondering why you're unable " +
 				"to enable the Build Camera.");
-
-		private static ConfigEntry<string> configToolNames
-		= configFile.Bind("General", "Tool_Names", DEFAULT_TOOL_NAMES,
-			"List of comma-separated tool names that will allow Build Camera.");
 
 		// This is how we "add" member variables to a class of the game.
 		private static Dictionary<Player, bool> inBuildMode = new Dictionary<Player, bool>();
@@ -174,13 +168,6 @@ namespace Valheim_Build_Camera
 			return (bool)Player.m_localPlayer && player == Player.m_localPlayer;
 		}
 
-		static string[] toolNames
-		{
-			get => configToolNames.Value.Split(',')
-				.Select(x => "$" + x.Trim())
-				.ToArray();
-		}
-
 		/// <summary>
 		/// Returns true when the item is a Build Camera-compatible tool such as hammer.
 		/// </summary>
@@ -188,8 +175,7 @@ namespace Valheim_Build_Camera
 		/// <returns></returns>
 		static bool IsTool(in ItemDrop.ItemData itemData)
 		{
-			return toolNames.Contains(itemData?.m_shared.m_name)
-				&& itemData?.m_shared.m_itemType == ItemDrop.ItemData.ItemType.Tool;
+			return itemData?.m_shared.m_buildPieces;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Removed the need to manually specify all possible hammer-items by checking if the item has pieces it can build.